### PR TITLE
Update JOSM and gradle-josm-plugin to latest release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'org.openstreetmap.josm' version '0.4.6'
 }
 
-version = 'git describe --always --dirty --tags'.execute().in.text.trim()
+version = '0.2.5'
 
 josm {
   josmCompileVersion = '13878'

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
-  id 'org.openstreetmap.josm' version '0.4.0'
+  id 'org.openstreetmap.josm' version '0.4.6'
 }
 
-//version = 'git describe --always --dirty'.execute().in.text.trim()
-version = '0.2.4'
+version = 'git describe --always --dirty --tags'.execute().in.text.trim()
+
 josm {
-  josmCompileVersion = '13576'
+  josmCompileVersion = '13878'
   manifest {
     description = 'Some useful tools for HOT and Missing Maps mappers.'
     mainClass = 'org.openstreetmap.josm.plugins.mapathoner.MapathonerPlugin'
-    minJosmVersion = 12643
+    minJosmVersion = 12726
     author = 'qeef'
     canLoadAtRuntime = true
     // iconPath = 'path/to/my/icon.svg'
@@ -20,8 +20,9 @@ josm {
     // oldVersionDownloadLink 123, 'v1.2.0', new URL('https://example.org/download/v1.2.0/MyAwesomePlugin.jar')
     // oldVersionDownloadLink  42, 'v1.0.0', new URL('https://example.org/download/v1.0.0/MyAwesomePlugin.jar')
   }
-  // i18n {
+  i18n {
+    pathTransformer = getGithubPathTransformer('qeef/mapathoner')
   //   bugReportEmail = 'me@example.com'
   //   copyrightHolder = 'John Doe'
-  // }
+  }
 }


### PR DESCRIPTION
Hi, great to see a new plugin with a Gradle build :tada: . I bumped the versions of gradle-josm-plugin and JOSM.

I also uncommented the `git describe` command again. With the `--tags` option the non-annotated tags will be picked up by the command.

The "pathTransformer" option is only relevant if you'd like to [translate the plugin](https://www.transifex.com/josm/josm/content/), but I thought I'd add it anyway because it doesn't hurt.